### PR TITLE
doc. docker-stack : conteneurs de substitution pour les développeurs externes

### DIFF
--- a/docker/_doc/docker-stack.md
+++ b/docker/_doc/docker-stack.md
@@ -87,16 +87,57 @@ alias docker-stack=$FC_ROOT/fc/docker/docker-stack
 
 - Link the cloned repository in the docker volumes
 
+  - If you are an internal developer
+
+  ```bash
+  cd $FC_ROOT/fc/docker/volumes/src
+  ln -s $FC_ROOT/fc
+  ln -s $FC_ROOT/rnipp-mock
+
+  ln -s $FC_ROOT/fc-apps
+
+  ln -s $FC_ROOT/usagers
+  ln -s $FC_ROOT/usagers-fca
+  ln -s $FC_ROOT/formulaire-usagers
+  ```
+
+  - If you are an external developer
+
+  ```bash
+  cd $FC_ROOT/fc/docker/volumes/src
+  ln -s $FC_ROOT/fc
+  ln -s $FC_ROOT/rnipp-mock
+  ```
+
+- If you are an external developer, create stubs for unavailable containers :
+
 ```bash
-cd $FC_ROOT/fc/docker/volumes/src
-ln -s $FC_ROOT/fc
-ln -s $FC_ROOT/rnipp-mock
+cat <<'EOF' >> $FC_ROOT/fc/docker/compose/stubs.yml
+version: '2.4'
 
-ln -s $FC_ROOT/fc-apps
-
-ln -s $FC_ROOT/usagers
-ln -s $FC_ROOT/usagers-fca
-ln -s $FC_ROOT/formulaire-usagers
+services:
+  fc-exploitation:
+    image: alpine
+    hostname: fc-exploitation
+  fc-support:
+    image: alpine
+    hostname: fc-support
+  fc-core:
+    image: alpine
+    hostname: fc-core
+  fsp1:
+    image: alpine
+    hostname: fsp1
+  fsp3:
+    image: alpine
+    hostname: fsp3
+  aidants-connect-mock:
+    image: alpine
+    hostname: aidants-connect-mock
+  fdp1:
+    image: alpine
+    hostname: fdp1
+EOF
 ```
 
 - Add to your host file `/etc/hosts`

--- a/docker/bash/config/docker.sh
+++ b/docker/bash/config/docker.sh
@@ -7,7 +7,7 @@ COMPOSE_FILES=$(find ${COMPOSE_DIR} -name "*.yml")
 VOLUMES_DIR="${FC_ROOT}/fc/docker/volumes"
 WORKING_DIR="$(cd "$(dirname "${0}")" >/dev/null 2>&1 && pwd)"
 
-DOCKER_REGISTRY_URI="<france-connect-registry>/fc/nodejs:${NODE_VERSION}-dev"
+DOCKER_REGISTRY_URI="${FC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev"
 
 # https://docs.docker.com/compose/reference/envvars/#compose_file
 COMPOSE_PATH_SEPARATOR=":"


### PR DESCRIPTION
Ajout d'instructions pour les développeurs externes afin de créer des substituts pour les conteneurs Docker manquants. Sans ces conteneurs, _docker-stack_ ne fonctionne pas.