### PR TITLE
support for unregistered Relying Party (uRP)

### DIFF
--- a/back/instances/core-fcp-low/src/config/oidc-provider.ts
+++ b/back/instances/core-fcp-low/src/config/oidc-provider.ts
@@ -140,7 +140,7 @@ export default {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       application_type: 'web',
     },
-    responseTypes: ['code'],
+    responseTypes: ['code', 'id_token'],
     revocationEndpointAuthMethods: ['client_secret_post', 'private_key_jwt'],
     tokenEndpointAuthMethods: ['client_secret_post', 'private_key_jwt'],
     enabledJWA: {

--- a/back/libs/core/src/dto/interaction.dto.ts
+++ b/back/libs/core/src/dto/interaction.dto.ts
@@ -5,4 +5,5 @@ export class Interaction {
   @IsAscii()
   @Length(21, 21)
   readonly uid: string;
+  params: any;
 }

--- a/back/libs/core/src/services/core-acr.service.ts
+++ b/back/libs/core/src/services/core-acr.service.ts
@@ -5,6 +5,7 @@ import { OidcAcrService } from '@fc/oidc-acr';
 import { OidcProviderService } from '@fc/oidc-provider';
 
 import { CoreInvalidAcrException, CoreLowAcrException } from '../exceptions';
+import { Interaction } from '@fc/core';
 
 @Injectable()
 export class CoreAcrService {
@@ -62,5 +63,10 @@ export class CoreAcrService {
       );
       throw new CoreLowAcrException();
     }
+  }
+
+  async findInteraction(interactionId): Promise<Interaction> {
+    const provider = this.oidcProvider.getProvider();
+    return await provider.Interaction.find(interactionId);
   }
 }

--- a/back/libs/oidc-provider/src/oidc-provider.service.ts
+++ b/back/libs/oidc-provider/src/oidc-provider.service.ts
@@ -80,6 +80,21 @@ export class OidcProviderService {
       throw new OidcProviderInitialisationException();
     }
 
+    const { redirectUriAllowed, postLogoutRedirectUriAllowed } = this.provider.Client.prototype;
+    this.provider.Client.prototype.redirectUriAllowed = function publicRedirectUriAllowed(redirectUri) {
+      if (this.clientId == 'unregisteredRelyingParty') {
+        return true;
+      }
+      return redirectUriAllowed.call(this, redirectUri);
+    };
+
+    this.provider.Client.prototype.postLogoutRedirectUriAllowed = function publicPostLogoutRedirectUriAllowed(uri) {
+      if (this.clientId == 'unregisteredRelyingParty') {
+        return true;
+      }
+      return postLogoutRedirectUriAllowed.call(this, uri);
+    };
+
     this.oidcProviderConfigApp.setProvider(this.provider);
 
     this.logger.debug('Mouting oidc-provider middleware');

--- a/back/libs/service-provider-adapter-mongo/src/dto/service-provider-adapter-mongo.dto.ts
+++ b/back/libs/service-provider-adapter-mongo/src/dto/service-provider-adapter-mongo.dto.ts
@@ -114,4 +114,14 @@ export class ServiceProviderAdapterMongoDTO {
   @IsOptional()
   @IsEnum(platform)
   readonly platform?: platform;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  readonly grant_types?: string[];
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  readonly response_types?: string[];
 }

--- a/back/libs/service-provider-adapter-mongo/src/service-provider-adapter-mongo.service.spec.ts
+++ b/back/libs/service-provider-adapter-mongo/src/service-provider-adapter-mongo.service.spec.ts
@@ -206,6 +206,8 @@ describe('ServiceProviderAdapterMongoService', () => {
       _id: false,
       active: true,
       claims: true,
+      grant_types: true ,
+      response_types: true,
       // openid defined property names
       // eslint-disable-next-line @typescript-eslint/naming-convention
       client_secret: true,

--- a/back/libs/service-provider-adapter-mongo/src/service-provider-adapter-mongo.service.ts
+++ b/back/libs/service-provider-adapter-mongo/src/service-provider-adapter-mongo.service.ts
@@ -75,6 +75,8 @@ export class ServiceProviderAdapterMongoService
         client_secret: true,
         scopes: true,
         claims: true,
+        grant_types: true,
+        response_types: true,
         // openid defined property names
         // eslint-disable-next-line @typescript-eslint/naming-convention
         redirect_uris: true,

--- a/docker/volumes/mongo-fcp-low/scripts/db-states/_default/sp.js
+++ b/docker/volumes/mongo-fcp-low/scripts/db-states/_default/sp.js
@@ -239,6 +239,52 @@ const fsp = {
     ssoDisabled: false,
     platform: 'CORE_FCP',
   },
+  'FSP-PUB-LOW': {
+    name: "fsp-pub-low",
+    title: "FSP PUBLIC - LOW",
+    eidas: 2,
+    site: "https://unregisteredRelyingParty.docker.dev-franceconnect.fr/login",
+    redirect_uris: [
+      "https://unregisteredRelyingParty.docker.dev-franceconnect.fr/oidc-callback",// unused
+    ],
+    post_logout_redirect_uris: [
+      "https://unregisteredRelyingParty.docker.dev-franceconnect.fr/logout-callback",// unused
+    ],
+    client_secret:// unused
+    "4eQRa1ab1h8jIKVs53cW8FBUGIa5KQLlXQpdP/lGe3EJifIwUMHR0w6HKxu3ccGzR0y6+aS2wLAifrmhsT76TtVCvnNQAF5rONzLejQ7Hqy1LBF8TAUpx+8yFak=",
+    key: "unregisteredRelyingParty", // shared public client id
+    entityId:
+      "abeba7280c42968a2df6ae0e4d6fc2ce30cb961628b5a6440bc1e969f334181a",
+    credentialsFlow: false,
+    featureHandlers: { none: "" },
+    email: "fsp-pub@franceconnect.loc",
+    IPServerAddressesAndRanges: ["1.1.1.1"],
+    active: true,
+    type: "public",
+    __v: 4,
+    updatedAt: new Date("2019-04-24 17:09:17"),
+    updatedBy: "admin",
+    scopes: [
+      "openid",
+    ],
+    claims: ['amr'],
+    grant_types: ['implicit'],
+    response_types: ['id_token'],
+    id_token_signed_response_alg: "ES256",
+    id_token_encrypted_response_alg: "",
+    id_token_encrypted_response_enc: "",
+    userinfo_signed_response_alg: "ES256",
+    userinfo_encrypted_response_alg: "",
+    userinfo_encrypted_response_enc: "",
+    jwks_uri:// unused
+      "https://unregisteredRelyingParty.docker.dev-franceconnect.fr/client/.well-known/keys",
+    idpFilterExclude: true,
+    idpFilterList: [],
+    identityConsent: false,
+    trustedIdentity: false,
+    ssoDisabled: false,
+    platform: 'CORE_FCP',
+  },
 };
 
 /* ------------------------------------------------------------------------------- */


### PR DESCRIPTION
### Changements apportés
Ce PR implémente un concept simple de _unregistered Relying Parties_ (uRP).

Cette fonctionnalité permet à des _Relying Parties_ non préalablement enregistrées d’utiliser FranceConnect pour vérifier que leurs utilisateurs sont des personnes physiques et distinctes.

Le scope OpenID est limité à l'identifiant technique (_sub_), donc aucune donnée personnelle ne peut être transmise. De plus, le _sub_ est _Pairwise Pseudonymous Identifier_ (PPID), ce qui empêche les corrélations parmi les uRP.

Comme cette implémentation est compatible avec les spécifications OpenID Connect, elle ne requiert aucun changement dans l'implémentation des _Relying Parties_.

### Justification
Cette fonctionnalité permet à des applications tierces de se protéger contre les attaques Sybil. En sécurité informatique, l’attaque Sybil correspond à la création de multiples faux comptes par une même personne. Par exemple, sur un réseau social, un utilisateur qui crée plusieurs profils fictifs. C'est une attaque simple à mettre en œuvre sur Internet, mais pourtant compliquée à parer (un même attaquant peut utiliser plusieurs comptes emails, plusieurs numéros de téléphone, plusieurs adresses IP). Afin de se protéger contre cette attaque, certaines applications ont recours à des pratiques intrusives telles que demander aux utilisateurs de fournir une pièce d'identité ou un numéro de carte bancaire. Néanmoins, ce type de vérification n’est pas efficace contre les attaques Sybil (un même utilisateur peut utiliser plusieurs numéros de carte bancaire), et met en péril la confidentialité des données personnelles des utilisateurs.

Cette fonctionnalité est une solution alternative à la fois plus robuste face aux attaques Sybil, et sans utiliser les données personnelles des utilisateurs.

Voici des exemples d'applications tierces qui peuvent bénéficier du support uRP :

- Réseau social : lutte contre le spam, les bots, et le harcèlement (actions généralement commises au travers de faux profils)
- Site de vote en ligne : garantir 1 vote par personne (par exemple dans l’application [Agora](https://www.agora.gouv.fr/))
- Jeux vidéo : distribution équitable d'objets virtuels (par exemple 1 par personne)
- Service en ligne : offres d'essai limitées par personne

### Détails techniques
Comme les uRP ne sont pas connus à l'avance du _provider_ (FranceConnect), cela induit plusieurs contraintes :
- Le mode _implicit flow_ est utilisé car il ne requiert pas de secret _client_secret_ partagé entre uRP et _provider_.
- Les uRP partagent un même _client_id_ constant.
- Les uRP fournissent l’adresse de callback de leur choix.
- Le _sub_ est dérivé, entre autres, de l'adresse de callback du uRP afin de garantir que le _sub_ est un PPID (spécifique à chaque couple utilisateur-uRP).