### PR TITLE
fix(dto2form): Improper neutralization of special elements used in a command in shell-quote

### DIFF
--- a/back/libs/dto2form/src/helpers/convert-regexp-to-string.helper.spec.ts
+++ b/back/libs/dto2form/src/helpers/convert-regexp-to-string.helper.spec.ts
@@ -22,7 +22,7 @@ describe('convertRegExpToStrings', () => {
   it('should return validator with complex regExp transform into string', () => {
     // Given
     const validationArgsMock = [
-      /^[A-Za-zÀ-žØ-öø-ÿ0-9\s,.:!\(\)_'\-\u0026-\u002f]+$/,
+      /^[A-Za-zÀ-ÿ0-9\s,.:!\(\)_'\-\u0026-\u002f]+$/,
     ];
 
     const expected = [


### PR DESCRIPTION
https://github.com/france-connect/sources/blob/6fa80f703bd0f291932662561a9f5792317a279d/back/libs/dto2form/src/helpers/convert-regexp-to-string.helper.spec.ts#L25-L25

fix the issue need to refactor the regular expression on line 25 to remove the overlapping ranges while preserving the intended functionality. The ranges `À-ž`, `Ø-ö`, and `ø-ÿ` should be combined into a single, non-overlapping range that includes all intended characters. This can be achieved by using `À-ÿ`, which encompasses all characters from `À` to `ÿ` without redundancy. The updated regular expression will be clearer and easier to maintain.




## References
[CVE-2021-42740: Improper Neutralization of Special Elements used in a Command in Shell-quote](https://github.com/advisories/GHSA-g4rg-993r-mgx7)
[Exploiting CVE-2021-42740](https://wh0.github.io/2021/10/28/shell-quote-rce-exploiting.html)
[no-obscure-range](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-obscure-range.html)
[The regex [,-.]](https://pboyd.io/posts/comma-dash-dot/)
[CWE-20](https://cwe.mitre.org/data/definitions/20.html)
